### PR TITLE
Renew a missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
         "bitgo-utxo-lib": "git+https://github.com/upbqdn/bitgo-utxo-lib.git",
-        "equihashverify": "git+https://github.com/upbqdn/equihashverify.git",
+        "equihashverify": "git+https://github.com/s-nomp/equihashverify.git",
         "verushash": "git+https://github.com/VerusCoin/verushash-node#e6572f345b8c24e4a1212f6c9eb66c1c400d83e1",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
         "bitgo-utxo-lib": "git+https://github.com/upbqdn/bitgo-utxo-lib.git",
-        "equihashverify": "git+https://github.com/s-nomp/equihashverify.git",
+        "equihashverify": "git+https://github.com/upbqdn/equihashverify.git",
         "verushash": "git+https://github.com/VerusCoin/verushash-node#e6572f345b8c24e4a1212f6c9eb66c1c400d83e1",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "async": "^2.6.1",
         "base58-native": "^0.1.4",
         "bignum": "^0.13.0",
-        "bitgo-utxo-lib": "git+https://github.com/miketout/bitgo-utxo-lib.git",
+        "bitgo-utxo-lib": "git+https://github.com/upbqdn/bitgo-utxo-lib.git",
         "equihashverify": "git+https://github.com/s-nomp/equihashverify.git",
         "verushash": "git+https://github.com/VerusCoin/verushash-node#e6572f345b8c24e4a1212f6c9eb66c1c400d83e1",
         "merkle-bitcoin": "^1.0.2",


### PR DESCRIPTION
## Motivation

The dependency `bitgo-utxo-lib` transitively depends on https://github.com/BitGo/blake2b-wasm, which was recently deleted from GitHub.

## Solution

- I found a fork of the missing https://github.com/BitGo/blake2b-wasm, and forked it under my GitHub account: https://github.com/upbqdn/blake2b-wasm.
- I created a fork of https://github.com/michaeltout/blake2b here: https://github.com/upbqdn/blake2b, and made it depend on https://github.com/upbqdn/blake2b-wasm instead of the missing https://github.com/BitGo/blake2b-wasm.
- I also forked https://github.com/miketout/bitgo-utxo-lib here: https://github.com/upbqdn/bitgo-utxo-lib, and made it depend on https://github.com/upbqdn/blake2b instead of https://github.com/michaeltout/blake2b.
- This PR points to https://github.com/upbqdn/bitgo-utxo-lib instead of https://github.com/miketout/bitgo-utxo-lib.
